### PR TITLE
fix: moving to 255 calculations

### DIFF
--- a/ios/RootViewBackground.mm
+++ b/ios/RootViewBackground.mm
@@ -11,7 +11,7 @@ RCT_EXPORT_METHOD(setBackground:(float)red green:(float)green blue:(float)blue a
 {
     dispatch_async( dispatch_get_main_queue(), ^{
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        rootViewController.view.backgroundColor = [[UIColor alloc] initWithRed:red/255 green:green/255 blue:blue/255 alpha:alpha];
+        rootViewController.view.backgroundColor = [[UIColor alloc] initWithRed:red/255 green:green/255 blue:blue/255 alpha:alpha/255];
     });
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ function setRootViewBackgroundColor(color: string) {
     parsedColor.toRgb().r,
     parsedColor.toRgb().g,
     parsedColor.toRgb().b,
-    1
+    255
   );
 }
 


### PR DESCRIPTION
Moving alpha's argument to same format (0-255) as "r" "g" and "b" othetwise on android we have situation when alpha is almost 0 all the time:
`val parsedColor = Color.argb(a.toInt(), r.toInt(), g.toInt(), b.toInt());` - withount fix passing for example white color here we have `Color.argb(1,255,255,255)`